### PR TITLE
Add unit test for Path weight set error

### DIFF
--- a/spec/suites/layer/vector/PolylineSpec.js
+++ b/spec/suites/layer/vector/PolylineSpec.js
@@ -212,4 +212,15 @@ describe('Polyline', function () {
 			expect(polyline._latlngs).to.eql([L.latLng([1, 2])]);
 		});
 	});
+
+	describe("#style", function () {
+		it("can set weight after being added to the map", function () {
+			var polyline = new L.Polyline([]).addTo(map);
+			polyline.setStyle({
+				weight: 3,
+			});
+			expect(map.hasLayer(polyline)).to.be(true);
+			expect(polyline.options.weight).to.be(3);
+		});
+	});
 });


### PR DESCRIPTION
Add the unit test requested by [this comment](https://github.com/Leaflet/Leaflet/pull/6941#issuecomment-695177716).

The test fails with the currently released v1.7.1 Leaflet version, but is fixed by the change in #6941.